### PR TITLE
fix: update docs workflow to use ubuntu-latest runner

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Ubuntu-20.04 runners are deprecated and no longer available in GitHub Actions. This was causing the docs workflow to hang waiting for a runner. Updated to ubuntu-latest to match other workflows in the repository.