### PR TITLE
Remove and deprecate Discord integration

### DIFF
--- a/ngv_reports_ibkr/adapters.py
+++ b/ngv_reports_ibkr/adapters.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import warnings
 
 from loguru import logger
 import pandas as pd
@@ -169,6 +170,13 @@ class ReportOutputAdapterPandas(BaseModel):
     
         
 class ReportOutputAdapterDiscord(BaseModel):
+    """
+    Discord output adapter for IBKR reports.
+
+    .. deprecated::
+        This class is deprecated and will be removed in a future version.
+        Discord integration is no longer supported.
+    """
     class Config:
         arbitrary_types_allowed = True
 
@@ -181,19 +189,49 @@ class ReportOutputAdapterDiscord(BaseModel):
     def public_account_id(self):
         """
         Only publish the first 3 digits of account
+
+        .. deprecated::
+            This property is deprecated and will be removed in a future version.
+            Discord integration is no longer supported.
         """
+        warnings.warn(
+            "ReportOutputAdapterDiscord.public_account_id is deprecated and will be removed in a future version. "
+            "Discord integration is no longer supported.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.account_id[0:4]
 
     def put_notifications(self):
         """
         Main method called. Calls into specific functions
+
+        .. deprecated::
+            This method is deprecated and will be removed in a future version.
+            Discord integration is no longer supported.
         """
+        warnings.warn(
+            "ReportOutputAdapterDiscord.put_notifications is deprecated and will be removed in a future version. "
+            "Discord integration is no longer supported.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.put_expiry_notifications()
 
     def put_expiry_notifications(self):
         """
         Notify discord with expiring positions in X days
+
+        .. deprecated::
+            This method is deprecated and will be removed in a future version.
+            Discord integration is no longer supported.
         """
+        warnings.warn(
+            "ReportOutputAdapterDiscord.put_expiry_notifications is deprecated and will be removed in a future version. "
+            "Discord integration is no longer supported.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         expiring_positions = self._get_expiring_positions(
             within_x_days=self.expiring_positions_within_x_days
         )
@@ -217,7 +255,18 @@ class ReportOutputAdapterDiscord(BaseModel):
     def _get_expiring_positions(self, within_x_days: int) -> pd.DataFrame:
         """
         Among open positions, get expiring positions within X days
+
+        .. deprecated::
+            This method is deprecated and will be removed in a future version.
+            Discord integration is no longer supported.
         """
+        warnings.warn(
+            "ReportOutputAdapterDiscord._get_expiring_positions is deprecated and will be removed in a future version. "
+            "Discord integration is no longer supported.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         df = self.report.open_positions_by_account_id(self.account_id)
 
         # get latest positions

--- a/ngv_reports_ibkr/config_helpers.py
+++ b/ngv_reports_ibkr/config_helpers.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from typing import Dict
 
 from dotenv import dotenv_values
@@ -38,10 +39,20 @@ def get_discord_webhook_url(configs: Dict) -> str:
     """
     Returns the discord portfolios webhook
 
+    .. deprecated::
+        This function is deprecated and will be removed in a future version.
+        Discord integration is no longer supported.
+
     Args:
         configs (Dict): env file contents
 
     Returns:
         str: discord webhook url
     """
+    warnings.warn(
+        "get_discord_webhook_url is deprecated and will be removed in a future version. "
+        "Discord integration is no longer supported.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return configs["PORTFOLIOS_DISCORD_WEBHOOK_URL"]

--- a/ngv_reports_ibkr/download_trades.py
+++ b/ngv_reports_ibkr/download_trades.py
@@ -18,7 +18,17 @@ from ngv_reports_ibkr.custom_flex_report import CustomFlexReport
 def process_report_discord(report: CustomFlexReport, discord_webhook_url: str):
     """
     Process report through discord output adapter
+
+    .. deprecated::
+        This function is deprecated and will be removed in a future version.
+        Discord integration is no longer supported.
     """
+    warnings.warn(
+        "process_report_discord is deprecated and will be removed in a future version. "
+        "Discord integration is no longer supported.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     for account_id in report.account_ids():
         output_adapter = ReportOutputAdapterDiscord(
             account_id=account_id,


### PR DESCRIPTION
Add deprecation warnings to all Discord-related functionality:
- ReportOutputAdapterDiscord class and all its methods
- get_discord_webhook_url() function
- process_report_discord() function

These features are no longer supported and will be removed in a future version.