### PR TITLE
Review and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 # NextGenVol IBKR Reports
 Python package to generate reports from Interactive Brokers.
 
+**[📚 Documentation](https://westonplatter.github.io/ngv-reports-ibkr/)** | [API Reference](https://westonplatter.github.io/ngv-reports-ibkr/api.html)
+
 > **Disclaimer**: This project is not affiliated with or endorsed by Interactive Brokers. It is an independent tool for processing and analyzing Flex Report data from Interactive Brokers' API.
 
 ## Installing

--- a/ngv_reports_ibkr/adapters.py
+++ b/ngv_reports_ibkr/adapters.py
@@ -158,14 +158,14 @@ class ReportOutputAdapterPandas(BaseModel):
 
         Args:
             aid (str): account id
-        
+
         Returns:
             dict: dict of dfs
         """
         return {
-            "trades": self.gen_trades_df(aid),
-            "closed_trades": self.gen_closed_trades_df(aid),
-            "open_positions": self.gen_open_positions(aid),
+            "trades": self.put_trades(aid),
+            "closed_trades": self.put_close_trades(aid),
+            "open_positions": self.put_open_positions(aid),
         }
     
         
@@ -173,7 +173,7 @@ class ReportOutputAdapterDiscord(BaseModel):
     """
     Discord output adapter for IBKR reports.
 
-    .. deprecated::
+    .. deprecated:: 0.2.0
         This class is deprecated and will be removed in a future version.
         Discord integration is no longer supported.
     """
@@ -190,7 +190,7 @@ class ReportOutputAdapterDiscord(BaseModel):
         """
         Only publish the first 3 digits of account
 
-        .. deprecated::
+        .. deprecated:: 0.2.0
             This property is deprecated and will be removed in a future version.
             Discord integration is no longer supported.
         """
@@ -206,7 +206,7 @@ class ReportOutputAdapterDiscord(BaseModel):
         """
         Main method called. Calls into specific functions
 
-        .. deprecated::
+        .. deprecated:: 0.2.0
             This method is deprecated and will be removed in a future version.
             Discord integration is no longer supported.
         """
@@ -222,7 +222,7 @@ class ReportOutputAdapterDiscord(BaseModel):
         """
         Notify discord with expiring positions in X days
 
-        .. deprecated::
+        .. deprecated:: 0.2.0
             This method is deprecated and will be removed in a future version.
             Discord integration is no longer supported.
         """
@@ -256,7 +256,7 @@ class ReportOutputAdapterDiscord(BaseModel):
         """
         Among open positions, get expiring positions within X days
 
-        .. deprecated::
+        .. deprecated:: 0.2.0
             This method is deprecated and will be removed in a future version.
             Discord integration is no longer supported.
         """

--- a/ngv_reports_ibkr/config_helpers.py
+++ b/ngv_reports_ibkr/config_helpers.py
@@ -39,7 +39,7 @@ def get_discord_webhook_url(configs: Dict) -> str:
     """
     Returns the discord portfolios webhook
 
-    .. deprecated::
+    .. deprecated:: 0.2.0
         This function is deprecated and will be removed in a future version.
         Discord integration is no longer supported.
 

--- a/ngv_reports_ibkr/download_trades.py
+++ b/ngv_reports_ibkr/download_trades.py
@@ -19,7 +19,7 @@ def process_report_discord(report: CustomFlexReport, discord_webhook_url: str):
     """
     Process report through discord output adapter
 
-    .. deprecated::
+    .. deprecated:: 0.2.0
         This function is deprecated and will be removed in a future version.
         Discord integration is no longer supported.
     """
@@ -114,8 +114,9 @@ def execute_discord_for_accounts(
     """
     Execute the discord notifications process for accounts
 
-    .. deprecated::
+    .. deprecated:: 0.2.0
         This function is deprecated and will be removed in a future version.
+        Discord integration is no longer supported.
 
     Args:
         report_name (str): the report to execute. Expected options: daily, weekly, annual


### PR DESCRIPTION
## Changes

- Add GitHub Pages documentation link to README
- Fix bug in ReportOutputAdapterPandas.put_all() calling non-existent methods
- Add version numbers (0.2.0) to all Sphinx deprecation directives
- Improve Sphinx documentation rendering for deprecated features

Fixes:
- ReportOutputAdapterPandas.put_all() now calls correct methods: put_trades(), put_close_trades(), put_open_positions()
- Deprecation warnings now show "Deprecated since version 0.2.0" instead of "Deprecated since version This:"